### PR TITLE
feat: Notification Things

### DIFF
--- a/src/lib/component/Button.svelte
+++ b/src/lib/component/Button.svelte
@@ -19,7 +19,6 @@
 	export let color: ButtonTheme = 'BLUE';
 	export let icon: IconSource | undefined = undefined;
 	export let full: string = 'true';
-	export let text: string = 'Button';
 
 	const dispatch = createEventDispatcher<{
 		click: void;
@@ -39,5 +38,5 @@
 		<Icon class="w-6 h-full mr-2" src={icon} />
 	{/if}
 
-	{text}
+	<slot />
 </button>

--- a/src/lib/component/Button.svelte
+++ b/src/lib/component/Button.svelte
@@ -38,5 +38,5 @@
 		<Icon class="w-6 h-full mr-2" src={icon} />
 	{/if}
 
-	<slot />
+	<slot>Button</slot>
 </button>

--- a/src/lib/component/Toggle.svelte
+++ b/src/lib/component/Toggle.svelte
@@ -1,32 +1,32 @@
 <script lang="ts">
-    import { createEventDispatcher } from "svelte";
+	import { createEventDispatcher } from "svelte";
 
-    let clazz: string = "";
-    export { clazz as class };
+	let clazz: string = "";
+	export { clazz as class };
 
-    export let text: string;
-    export let default_state: string;
+	export let text: string;
+	export let default_state: string;
 
-    const dispatch = createEventDispatcher();
-    let state = default_state == "true";
+	const dispatch = createEventDispatcher();
+	let state = default_state == "true";
 
-    const on_click = () => {
-        state = !state;
-        dispatch("click", state);
-    };
+	const on_click = () => {
+		state = !state;
+		dispatch("click", state);
+	};
 </script>
 
 <label class="relative inline-flex items-center cursor-pointer {clazz}">
-    <input
-        type="checkbox"
-        class="sr-only peer"
-        bind:checked={state}
-        on:click={on_click}
-    />
-    <div
-        class="w-11 h-7 transition rounded-full bg-slate-800/[0.6] peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-1 after:left-[5px] after:bg-gray-200 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:drop-shadow peer-checked:after:translate-x-3.5"
-    />
-    <span class="ml-3 text-sm font-medium text-gray-300 dark:text-gray-300"
-        >{text}</span
-    >
+	<input
+		type="checkbox"
+		class="sr-only peer"
+		bind:checked={state}
+		on:click={on_click}
+	/>
+	<div
+		class="w-11 h-7 transition rounded-full bg-slate-800/[0.6] peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-1 after:left-[5px] after:bg-gray-200 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:drop-shadow peer-checked:after:translate-x-3.5"
+	/>
+	<span class="ml-3 text-sm font-medium text-gray-300 dark:text-gray-300"
+		>{text}</span
+	>
 </label>

--- a/src/lib/component/Toggle.svelte
+++ b/src/lib/component/Toggle.svelte
@@ -4,14 +4,12 @@
 	let clazz: string = '';
 	export { clazz as class };
 
-	export let default_state: string;
-
 	const dispatch = createEventDispatcher();
-	let state = default_state == 'true';
+	export let checked: boolean = false;
 
 	const on_click = () => {
-		state = !state;
-		dispatch('click', state);
+		checked = !checked;
+		dispatch('click', checked);
 	};
 </script>
 
@@ -19,7 +17,7 @@
 	<input
 		type="checkbox"
 		class="sr-only peer"
-		bind:checked={state}
+		bind:checked
 		on:click={on_click}
 	/>
 	<div

--- a/src/lib/component/Toggle.svelte
+++ b/src/lib/component/Toggle.svelte
@@ -24,6 +24,6 @@
 		class="w-11 h-7 transition rounded-full bg-slate-800/[0.6] peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-1 after:left-[5px] after:bg-gray-200 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:drop-shadow peer-checked:after:translate-x-3.5"
 	/>
 	<span class="ml-3 text-sm font-medium text-gray-300 dark:text-gray-300"
-		><slot /></span
+		><slot>Toggle</slot></span
 	>
 </label>

--- a/src/lib/component/Toggle.svelte
+++ b/src/lib/component/Toggle.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
-	import { createEventDispatcher } from "svelte";
+	import { createEventDispatcher } from 'svelte';
 
-	let clazz: string = "";
+	let clazz: string = '';
 	export { clazz as class };
 
-	export let text: string;
 	export let default_state: string;
 
 	const dispatch = createEventDispatcher();
-	let state = default_state == "true";
+	let state = default_state == 'true';
 
 	const on_click = () => {
 		state = !state;
-		dispatch("click", state);
+		dispatch('click', state);
 	};
 </script>
 
@@ -27,6 +26,6 @@
 		class="w-11 h-7 transition rounded-full bg-slate-800/[0.6] peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-1 after:left-[5px] after:bg-gray-200 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:drop-shadow peer-checked:after:translate-x-3.5"
 	/>
 	<span class="ml-3 text-sm font-medium text-gray-300 dark:text-gray-300"
-		>{text}</span
+		><slot /></span
 	>
 </label>

--- a/src/lib/general/SideBar.svelte
+++ b/src/lib/general/SideBar.svelte
@@ -1,138 +1,143 @@
 <script lang="ts">
-    import { goto } from "$app/navigation";
-    import {
-        ArrowLeftOnRectangle,
-        ChevronUpDown,
-        Cog6Tooth,
-        GlobeAlt,
-        InformationCircle,
-    } from "@steeze-ui/heroicons";
-    import {
-        Popover,
-        PopoverButton,
-        PopoverPanel,
-    } from "@rgossiaux/svelte-headlessui";
-    import { fly } from "svelte/transition";
+	import { goto } from '$app/navigation';
+	import {
+		ArrowLeftOnRectangle,
+		ChevronUpDown,
+		Cog6Tooth,
+		GlobeAlt,
+		InformationCircle,
+	} from '@steeze-ui/heroicons';
+	import {
+		Popover,
+		PopoverButton,
+		PopoverPanel,
+	} from '@rgossiaux/svelte-headlessui';
+	import { fly } from 'svelte/transition';
 
-    import { createPopperActions } from "svelte-popperjs";
-    import { Icon } from "@steeze-ui/svelte-icon";
-    import SidebarRedirectionButton from "$lib/general/SidebarRedirectionButton.svelte";
-    import SidebarButton from "$lib/general/SidebarButton.svelte";
-    import { get } from "svelte/store";
-    import { UserContext, userContext } from "../../stores";
+	import { createPopperActions } from 'svelte-popperjs';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import SidebarRedirectionButton from '$lib/general/SidebarRedirectionButton.svelte';
+	import SidebarButton from '$lib/general/SidebarButton.svelte';
+	import { get } from 'svelte/store';
+	import { UserContext, userContext } from '../../stores';
 
-    let context: UserContext = get(userContext);
+	let context: UserContext = get(userContext);
 
-    const [popperRef, popperContent] = createPopperActions();
+	const [popperRef, popperContent] = createPopperActions();
 
-    // Example Popper configuration
-    const popperOptions = {
-        position: "bottom-end",
-        strategy: "absolute",
-    };
+	// Example Popper configuration
+	const popperOptions = {
+		position: 'bottom-end',
+		strategy: 'absolute',
+	};
 
-    function log_out() {
-        // Empty the user context in both local storage and writable
-        userContext.update((_) => new UserContext());
-        localStorage.removeItem("userContextData");
-        goto("/");
-    }
+	function log_out() {
+		// Empty the user context in both local storage and writable
+		userContext.update((_) => new UserContext());
+		localStorage.removeItem('userContextData');
+		goto('/');
+	}
 </script>
 
-<div class="fixed top-0 flex flex-col items-center bg-slate-700/[0.25] border-r border-slate-50/[0.15] min-w-fit w-60 h-full px-2 pt-3 pb-0 shadow-xl overflow-hidden main">
-    <div class="flex self-start items-center justify-center mb-6 mt-1.5 ml-4">
-        <img width="25px" src="https://moonclient.xyz/logo.png" alt="branding"/>
-        <p class="ml-3 text-lg text-gray-200"><b class="weight-700">Moon</b> Client</p>
-    </div>
+<div
+	class="fixed top-0 flex flex-col items-center bg-slate-700/[0.25] border-r border-slate-50/[0.15] min-w-fit w-60 h-full px-2 pt-3 pb-0 shadow-xl overflow-hidden main"
+>
+	<div class="flex self-start items-center justify-center mb-6 mt-1.5 ml-4">
+		<img
+			width="25px"
+			src="https://moonclient.xyz/logo.png"
+			alt="branding"
+		/>
+		<p class="ml-3 text-lg text-gray-200">
+			<b class="weight-700">Moon</b> Client
+		</p>
+	</div>
 
-    <div class="flex flex-col gap-y-2 w-full">
-        <SidebarRedirectionButton
-            icon={GlobeAlt}
-            text="Launch"
-            url="/launcher"
-        />
-    </div>
+	<div class="flex flex-col gap-y-2 w-full">
+		<SidebarRedirectionButton icon={GlobeAlt} url="/launcher"
+			>Launch</SidebarRedirectionButton
+		>
+	</div>
 
-    <div class="w-full gap-2 items-center mt-auto">
-        <SidebarRedirectionButton
-            class="mb-1"
-            low="true"
-            icon={Cog6Tooth}
-            text="Settings"
-            url="/launcher/settings"
-        />
-        <SidebarRedirectionButton
-            class="mb-3"
-            low="true"
-            icon={InformationCircle}
-            text="About"
-            url="/launcher/about"
-        />
-        <Popover class="relative mw-15rem" let:open>
-            <PopoverButton class="inline-flex w-full" use={[popperRef]}>
-                <div
-                    class="grow border-t border-slate-600/[0.9] flex items-center space-x-2 py-3 pr-2"
-                >
-                    <div
-                        class="inline-flex items-center justify-center w-9 h-9 overflow-hidden rounded-full bg-slate-600"
-                    >
-                        <span
-                            class="font-medium text-gray-600 dark:text-gray-300"
-                            >{context.username
-                                .substring(0, 1)
-                                .toUpperCase()}</span
-                        >
-                    </div>
-                    <div class="flex-grow text-left dark:text-white">
-                        <div
-                            class="text-white font-semibold overflow-ellipsis overflow-hidden whitespace-nowrap text-sm mw-8rem"
-                        >
-                            {context.username}
-                        </div>
-                        <div
-                            class="text-gray-400 font-semibold overflow-ellipsis overflow-hidden whitespace-nowrap font-0_6rem"
-                        >
-                            {context.rank}
-                        </div>
-                    </div>
-                    <Icon class="shrink-0 w-5 h-5" src={ChevronUpDown} />
-                </div>
-            </PopoverButton>
-            {#if open}
-                <div transition:fly|local={{ y: 5, duration: 200 }}>
-                    <PopoverPanel
-                        static
-                        use={[[popperContent, popperOptions]]}
-                        class="bg-slate-700 border border-slate-50/[0.15] rounded-lg mb-96 w-full z-10 p-2"
-                    >
-                        <SidebarButton
-                            class="w-full"
-                            low="true"
-                            icon={ArrowLeftOnRectangle}
-                            on:click={log_out}
-                            text="Logout"
-                        />
-                    </PopoverPanel>
-                </div>
-            {/if}
-        </Popover>
-    </div>
+	<div class="w-full gap-2 items-center mt-auto">
+		<SidebarRedirectionButton
+			class="mb-1"
+			icon={Cog6Tooth}
+			url="/launcher/settings"
+			low>Settings</SidebarRedirectionButton
+		>
+		<SidebarRedirectionButton
+			class="mb-3"
+			icon={InformationCircle}
+			url="/launcher/about"
+			low>About</SidebarRedirectionButton
+		>
+		<Popover class="relative mw-15rem" let:open>
+			<PopoverButton class="inline-flex w-full" use={[popperRef]}>
+				<div
+					class="grow border-t border-slate-600/[0.9] flex items-center space-x-2 py-3 pr-2"
+				>
+					<div
+						class="inline-flex items-center justify-center w-9 h-9 overflow-hidden rounded-full bg-slate-600"
+					>
+						<span
+							class="font-medium text-gray-600 dark:text-gray-300"
+							>{context.username
+								.substring(0, 1)
+								.toUpperCase()}</span
+						>
+					</div>
+					<div class="flex-grow text-left dark:text-white">
+						<div
+							class="text-white font-semibold overflow-ellipsis overflow-hidden whitespace-nowrap text-sm mw-8rem"
+						>
+							{context.username}
+						</div>
+						<div
+							class="text-gray-400 font-semibold overflow-ellipsis overflow-hidden whitespace-nowrap font-0_6rem"
+						>
+							{context.rank}
+						</div>
+					</div>
+					<Icon class="shrink-0 w-5 h-5" src={ChevronUpDown} />
+				</div>
+			</PopoverButton>
+			{#if open}
+				<div transition:fly|local={{ y: 5, duration: 200 }}>
+					<PopoverPanel
+						static
+						use={[[popperContent, popperOptions]]}
+						class="bg-slate-700 border border-slate-50/[0.15] rounded-lg mb-96 w-full z-10 p-2"
+					>
+						<SidebarButton
+							class="w-full"
+							icon={ArrowLeftOnRectangle}
+							on:click={log_out}
+							low
+						>
+							Log Out
+						</SidebarButton>
+					</PopoverPanel>
+				</div>
+			{/if}
+		</Popover>
+	</div>
 </div>
 
 <style lang="scss">
-    .main {
-        backdrop-filter: blur(100px);
-        .weight-700 {
-            font-weight: 700;
-        }
-        .mw-15rem {
-            max-width: 15rem;
-        }
-        .mw-8rem {
-            max-width: 8rem;
-        }
-        .font-0_6rem {
-            font-size: 0.6rem;
-        }
-    }
+	.main {
+		backdrop-filter: blur(100px);
+		.weight-700 {
+			font-weight: 700;
+		}
+		.mw-15rem {
+			max-width: 15rem;
+		}
+		.mw-8rem {
+			max-width: 8rem;
+		}
+		.font-0_6rem {
+			font-size: 0.6rem;
+		}
+	}
 </style>

--- a/src/lib/general/SidebarButton.svelte
+++ b/src/lib/general/SidebarButton.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { page } from '$app/stores';
 	import type { IconSource } from '@steeze-ui/heroicons/types';
 	import { Icon } from '@steeze-ui/svelte-icon';
 	import { createEventDispatcher } from 'svelte';
@@ -36,5 +35,5 @@
 			src={icon}
 		/>
 	{/if}
-	<slot />
+	<slot><em>{text}</em></slot>
 </button>

--- a/src/lib/general/SidebarButton.svelte
+++ b/src/lib/general/SidebarButton.svelte
@@ -1,34 +1,40 @@
 <script lang="ts">
-    import {page} from "$app/stores";
-    import type {IconSource} from "@steeze-ui/heroicons/types";
-    import {Icon} from "@steeze-ui/svelte-icon";
-    import {createEventDispatcher} from "svelte";
+	import { page } from '$app/stores';
+	import type { IconSource } from '@steeze-ui/heroicons/types';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import { createEventDispatcher } from 'svelte';
 
-    let clazz: string = "";
-    export {clazz as class};
+	let clazz: string = '';
+	export { clazz as class };
 
-    export let text: string = "Button";
-    export let icon: IconSource | undefined;
-    export let low: boolean;
+	export let text: string = 'Button';
+	export let icon: IconSource | undefined;
+	export let low: boolean;
 
-    function generateClasses(low: boolean): string {
-        let classList = ""
-        console.log(low)
-        if (!low) {
-            classList += " text-white"
-        }
-        return classList.trim()
-    }
+	function generateClasses(low: boolean): string {
+		let classList = '';
+		console.log(low);
+		if (!low) {
+			classList += ' text-white';
+		}
+		return classList.trim();
+	}
 
-    const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 </script>
 
-<button class="flex items-center text-sm font-medium text-neutral-400 rounded-lg text-center px-3 py-2.5 hover:bg-slate-800/[0.4] hover:text-white transition { generateClasses(low) } { clazz }"
-        on:click={ () => dispatch("click") }>
-    {#if icon}
-        <Icon style="width: 20px; height: 20px"
-              class="h-full mr-2 text-neutral-400 transition-all"
-              src={ icon }/>
-    {/if}
-    { text }
+<button
+	class="flex items-center text-sm font-medium text-neutral-400 rounded-lg text-center px-3 py-2.5 hover:bg-slate-800/[0.4] hover:text-white transition {generateClasses(
+		low
+	)} {clazz}"
+	on:click={() => dispatch('click')}
+>
+	{#if icon}
+		<Icon
+			style="width: 20px; height: 20px"
+			class="h-full mr-2 text-neutral-400 transition-all"
+			src={icon}
+		/>
+	{/if}
+	<slot />
 </button>

--- a/src/lib/general/SidebarRedirectionButton.svelte
+++ b/src/lib/general/SidebarRedirectionButton.svelte
@@ -1,36 +1,45 @@
 <script lang="ts">
-    import {page} from "$app/stores";
-    import type {IconSource} from "@steeze-ui/heroicons/types";
-    import {Icon} from "@steeze-ui/svelte-icon";
+	import { page } from '$app/stores';
+	import type { IconSource } from '@steeze-ui/heroicons/types';
+	import { Icon } from '@steeze-ui/svelte-icon';
 
-    let clazz: string = "";
-    export {clazz as class};
+	let clazz: string = '';
+	export { clazz as class };
 
-    export let text: string = "Button";
-    export let icon: IconSource | undefined;
-    export let url: string;
-    export let low: boolean;
+	export let text: string = '';
+	export let icon: IconSource | undefined;
+	export let url: string;
+	export let low: boolean = false;
 
-    function generateClasses(url: string, low: boolean): string {
-        let classList = ""
-        const onSameUrl = url == $page.route.id;
-        if (url == $page.route.id) {
-            classList += "bg-slate-800/[0.7]"
-        }
-        console.log(low)
-        if (!low || onSameUrl) {
-            classList += " text-white"
-        }
-        return classList.trim()
-    }
+	function generateClasses(url: string, low: boolean): string {
+		let classList = '';
+		const onSameUrl = url == $page.route.id;
+		if (url == $page.route.id) {
+			classList += 'bg-slate-800/[0.7]';
+		}
+		console.log(low);
+		if (!low || onSameUrl) {
+			classList += ' text-white';
+		}
+		return classList.trim();
+	}
 </script>
 
-<a href={ url }
-   class="flex items-center text-sm font-medium text-neutral-400 rounded-lg text-center px-3 py-2.5 hover:bg-slate-800/[0.4] hover:text-white transition { generateClasses(url, low) } { clazz }">
-    {#if icon}
-        <Icon style="width: 20px; height: 20px"
-              class="h-full mr-2 text-neutral-400 { $page.route.id == url ? 'text-white' : '' } transition-all"
-              src={ icon }/>
-    {/if}
-    { text }
+<a
+	href={url}
+	class="flex items-center text-sm font-medium text-neutral-400 rounded-lg text-center px-3 py-2.5 hover:bg-slate-800/[0.4] hover:text-white transition {generateClasses(
+		url,
+		low
+	)} {clazz}"
+>
+	{#if icon}
+		<Icon
+			style="width: 20px; height: 20px"
+			class="h-full mr-2 text-neutral-400 {$page.route.id == url
+				? 'text-white'
+				: ''} transition-all"
+			src={icon}
+		/>
+	{/if}
+	{text}<slot />
 </a>

--- a/src/lib/general/SidebarRedirectionButton.svelte
+++ b/src/lib/general/SidebarRedirectionButton.svelte
@@ -6,7 +6,7 @@
 	let clazz: string = '';
 	export { clazz as class };
 
-	export let text: string = '';
+	export let text: string = 'Button';
 	export let icon: IconSource | undefined;
 	export let url: string;
 	export let low: boolean = false;
@@ -41,5 +41,5 @@
 			src={icon}
 		/>
 	{/if}
-	{text}<slot />
+	<slot><em>{text}</em></slot>
 </a>

--- a/src/lib/notif/NotifHost.svelte
+++ b/src/lib/notif/NotifHost.svelte
@@ -1,49 +1,53 @@
 <script lang="ts">
-    import {
-        addNotification,
-        notificationStore,
-        registerCallback,
-        Notification as Notif,
-    } from './NotifHandler';
-    import Notification from './Notification.svelte';
-    import {flip} from "svelte/animate";
-    import {fade, fly} from "svelte/transition";
-    // global utility callbacks
-    registerCallback('dismiss-notif', () => true);
-    registerCallback('copy-text', (action, notif) => {
-        if (navigator.clipboard) {
-            navigator.clipboard.writeText(notif.message);
-            addNotification(
-                new Notif('Copied!', 'Copied to Clipboard', 'success')
-            );
-        } else
-            alert(`Your browser does not support copying to clipboard.
+	import {
+		addNotification,
+		notificationStore,
+		registerCallback,
+		Notification as Notif,
+		NotificationType,
+	} from './NotifHandler';
+	import Notification from './Notification.svelte';
+	import { flip } from 'svelte/animate';
+	import { fade, fly } from 'svelte/transition';
+	// global utility callbacks
+	registerCallback('dismiss-notif', () => true);
+	registerCallback('copy-text', (action, notif) => {
+		if (navigator.clipboard) {
+			if (!notif.message) console.warn('No Notification Message');
+			navigator.clipboard.writeText(notif.message ?? 'null');
+			addNotification(
+				new Notif(
+					'Copied!',
+					'Copied to Clipboard',
+					NotificationType.Success
+				)
+			);
+		} else
+			alert(`Your browser does not support copying to clipboard.
 Message: ${notif.message}`);
-        return true;
-    });
+		return true;
+	});
 </script>
 
-<div
-        class="notifs"
->
-    {#each $notificationStore as notif}
-        <div in:fade={{duration: 200}} out:fly={{x:100, duration: 300}}>
-            <Notification notification={notif}/>
-        </div>
-    {/each}
+<div class="notifs">
+	{#each $notificationStore as notif}
+		<div in:fade={{ duration: 200 }} out:fly={{ x: 100, duration: 300 }}>
+			<Notification notification={notif} />
+		</div>
+	{/each}
 </div>
 
 <style lang="scss">
-  .notifs {
-    position: fixed;
-    bottom: 0;
-    right: 0;
-    padding: 1rem;
-    z-index: 1000;
-    display: flex;
-    flex-direction: column-reverse;
-    align-items: flex-end;
-    gap: 1rem;
-    width: 350px;
-  }
+	.notifs {
+		position: fixed;
+		bottom: 0;
+		right: 0;
+		padding: 1rem;
+		z-index: 1000;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 1rem;
+		width: 350px;
+	}
 </style>

--- a/src/lib/notif/Notification.svelte
+++ b/src/lib/notif/Notification.svelte
@@ -1,138 +1,195 @@
 <script lang="ts">
-    import markdownIt from 'markdown-it/';
-    import {
-        callbacks,
-        registerCallback,
-        type Notification,
-    } from './NotifHandler';
-    import {onMount} from 'svelte';
-    import {Icon} from "@steeze-ui/svelte-icon";
-    import {ExclamationCircle} from "@steeze-ui/heroicons";
+	import markdownIt from 'markdown-it/';
+	import {
+		callbacks,
+		registerCallback,
+		type Notification,
+		NotificationType,
+	} from './NotifHandler';
+	import { onMount } from 'svelte';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import {
+		CheckCircle,
+		ExclamationCircle,
+		ExclamationTriangle,
+		InformationCircle,
+		QuestionMarkCircle,
+	} from '@steeze-ui/heroicons';
+	import type { IconSource } from '@steeze-ui/heroicons/types';
 
-    const md = markdownIt({
-        breaks: true,
-        linkify: true,
-        typographer: true,
-        html: false,
-    });
-    export let notification: Notification;
-    let firstFramePassed = false;
-    onMount(() => {
-        setTimeout(() => {
-            firstFramePassed = true;
-        }, 0);
-    });
-    $: actions = [
-        ...(notification.actions ?? []),
-        ...(notification.dismissable
-            ? [{name: 'Dismiss', callback: 'dismiss-notif'}]
-            : []),
-    ];
-    const generateFallbackCallback = (callback: string) => () => {
-        console.warn(`Callback ${callback} not found`);
-        return true;
-    };
+	const md = markdownIt({
+		breaks: true,
+		linkify: true,
+		typographer: true,
+		html: false,
+	});
+	export let notification: Notification;
+	let firstFramePassed = false;
+	onMount(() => {
+		setTimeout(() => {
+			firstFramePassed = true;
+		}, 0);
+	});
+	$: actions = [
+		...(notification.actions ?? []),
+		...(notification.dismissable
+			? [{ name: 'Dismiss', callback: 'dismiss-notif' }]
+			: []),
+	];
+	const generateFallbackCallback = (callback: string) => () => {
+		console.warn(`Callback ${callback} not found`);
+		return true;
+	};
+	let isLinux = false;
+	onMount(() => {
+		isLinux = navigator.userAgent.includes('Linux');
+	});
+	let autoselectedIcon: IconSource = (() => {
+		switch (notification.type) {
+			case NotificationType.Error:
+				return ExclamationCircle;
+			case NotificationType.Info:
+				return InformationCircle;
+			case NotificationType.Success:
+				return CheckCircle;
+			case NotificationType.Warning:
+				return ExclamationTriangle;
+			default:
+				return QuestionMarkCircle;
+		}
+	})();
 </script>
 
-<div
-        class="notif {notification.type} flex-col"
->
-    <div class="p-3">
-        <div class="flex flex-row">
-            <Icon class="w-9 mr-3" src={ ExclamationCircle }></Icon>
-            <div>
-                {#if notification.title}
-                    <div class="font-bold">{notification.title}</div>
-                {/if}
-                <div class="text-xs pt-1">
-                    {#if notification.message}
-                        {@html md.render(notification.message)}
-                    {/if}
-                </div>
-            </div>
-        </div>
-        <div class="pt-1" style="padding-left: 38px">
-            {#if actions.length > 0}
-                {#each actions as action}
-                    <button
-                            class="bg-slate-900 mr-2 rounded-md py-1 px-1.5 text-xs text-neutral-300"
-                            on:click={() => {
-    					if (action.callback) {
-    						const result = (
-    							callbacks[action.callback] ??
-    							generateFallbackCallback(action.callback)
-    						)(action, notification);
-    						if (result) notification.dismiss();
-    					}
-    				}}
-                    >
-                        {action.name}
-                    </button>
-                {/each}
-            {/if}
-        </div>
-    </div>
+<div class="notif {notification.type} flex-col">
+	<div class="p-3">
+		<div class="flex flex-row">
+			<Icon
+				class="w-9 mr-3"
+				src={notification.icon ?? autoselectedIcon}
+			/>
+			<div
+				style={[notification.title, notification.message].filter(
+					(v) => !!v
+				).length <= 1
+					? 'display:flex;align-items:center;justify-content:center;'
+					: ''}
+			>
+				{#if notification.title}
+					<div class="font-bold">{notification.title}</div>
+				{/if}
+				{#if notification.message}
+					<div class="text-xs pt-1">
+						{#if notification.message}
+							{@html md.render(notification.message)}
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</div>
+		{#if actions.length > 0}
+			<div
+				class="pt-1"
+				style="padding-left: 38px;{isLinux
+					? 'margin-left:0.7rem;'
+					: ''}"
+			>
+				{#each actions as action}
+					<button
+						class="bg-slate-900 mr-2 rounded-md py-1 px-1.5 text-xs text-neutral-300"
+						on:click={() => {
+							if (action.callback) {
+								const result = (
+									callbacks[action.callback] ??
+									generateFallbackCallback(action.callback)
+								)(action, notification);
+								if (result) notification.dismiss();
+							}
+						}}
+					>
+						{action.name}
+					</button>
+				{/each}
+			</div>
+		{/if}
+	</div>
 </div>
 
 <style lang="scss">
-  @use 'sass:color';
+	@use 'sass:color';
 
-  $errorAccent: #ff7777ff;
-  $infoAccent: #77c9ff;
-  $successAccent: #77ff77ff;
-  $warningAccent: #ffff77ff;
-  $baseColor: #1e293b;
-  .notif {
-    display: flex;
-    background: var(--background, #fff2);
-    backdrop-filter: blur(10px);
-    border-radius: 0.5rem;
-    width: 100%;
-    border: 1px solid var(--accent);
-    position: relative;
-    z-index: 2;
+	$errorAccent: #ff7777ff;
+	$infoAccent: #77c9ff;
+	$successAccent: #77ff77ff;
+	$warningAccent: #ffff77ff;
+	$baseColor: #1e293b;
+	.notif {
+		display: flex;
+		background: var(--background, #fff2);
+		backdrop-filter: blur(10px);
+		border-radius: 0.5rem;
+		width: 100%;
+		border: 1px solid var(--accent);
+		position: relative;
+		z-index: 2;
+		transition: 0.5s;
 
-    &.error {
-      --accent: #{$errorAccent};
-      --background: #{color.adjust($errorAccent, $blackness: +100%, $alpha: -0.7)};
-    }
+		&.error {
+			--accent: #{$errorAccent};
+			--background: #{color.adjust(
+					$errorAccent,
+					$blackness: +100%,
+					$alpha: -0.7
+				)};
+		}
 
-    &.info {
-      --accent: #{$infoAccent};
-      --background: #{color.adjust($infoAccent, $blackness: +100%, $alpha: -0.7)};
-    }
+		&.info {
+			--accent: #{$infoAccent};
+			--background: #{color.adjust(
+					$infoAccent,
+					$blackness: +100%,
+					$alpha: -0.7
+				)};
+		}
 
-    &.success {
-      --accent: #{$successAccent};
-      --background: #{color.adjust($successAccent, $blackness: +100%, $alpha: -0.7)};
-    }
+		&.success {
+			--accent: #{$successAccent};
+			--background: #{color.adjust(
+					$successAccent,
+					$blackness: +100%,
+					$alpha: -0.7
+				)};
+		}
 
-    &.warning {
-      --accent: #{$warningAccent};
-      --background: #{color.adjust($warningAccent, $blackness: +100%, $alpha: -0.7)};
-    }
+		&.warning {
+			--accent: #{$warningAccent};
+			--background: #{color.adjust(
+					$warningAccent,
+					$blackness: +100%,
+					$alpha: -0.7
+				)};
+		}
 
-    &::before,
-    &::after {
-      content: '';
-      display: block;
-      height: 100%;
-      width: 100%;
-      position: absolute;
-      top: 0;
-      left: 0;
-      background: var(--accent);
-      opacity: 0.2;
-      filter: blur(25px);
-      pointer-events: none;
-    }
+		&::before,
+		&::after {
+			content: '';
+			display: block;
+			height: 100%;
+			width: 100%;
+			position: absolute;
+			top: 0;
+			left: 0;
+			background: var(--accent);
+			opacity: 0.2;
+			filter: blur(25px);
+			pointer-events: none;
+		}
 
-    &::before {
-      z-index: 1;
-    }
+		&::before {
+			z-index: 1;
+		}
 
-    &::after {
-      z-index: 3;
-    }
-  }
+		&::after {
+			z-index: 3;
+		}
+	}
 </style>

--- a/src/lib/notif/RNG.ts
+++ b/src/lib/notif/RNG.ts
@@ -1,0 +1,16 @@
+/* used for ids */
+export const jsf32 = (a: number, b: number, c: number, d: number) => (min: number = 0, max: number = 1) => {
+	a |= 0; b |= 0; c |= 0; d |= 0;
+	const t = a - (b << 27 | b >>> 5) | 0;
+	a = b ^ (c << 17 | c >>> 15);
+	b = c + d | 0;
+	c = d + t | 0;
+	d = a + t | 0;
+	if (min > max) {
+		const storage = min;
+		min = max;
+		max = storage;
+	}
+	return ((d >>> 0) / 4294967296) * (max - min) + min;
+};
+export default jsf32;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,13 +4,31 @@
 	import { onMount } from 'svelte';
 	import '../app.css';
 	import { svelteMount } from '$lib/notif/NotifHandler';
-	onMount(() => {
+	onMount(async () => {
 		svelteMount();
+		while (document.getElementById('linux-font-moment') == null) {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+		const style = document.getElementById('linux-font-moment');
+		if (
+			navigator.userAgent.toLowerCase().includes('linux') &&
+			style !== null
+		)
+			style.innerHTML = `/* monkey patch because webkitgtk is shit */
+${[100, 200, 300, 400, 500, 600, 700, 800, 900]
+	.map(
+		(weight) =>
+			`/*inter@${weight} (varweight patch)*/@font-face {font-family: 'Inter';font-style: normal;font-weight: ${weight};font-display: swap;src: url('https://fonts-cdn.nexuspipe.com/fonts/Inter-5323287c005292e89e320f96952a52f6f45e7d570baff1ae5ad41c9d38a76dd13838025ef07489d53a847b5f201b1abaf7f1ba55c385d684ed7bc3082926c7f5.woff2') format('woff2'), url('https://fonts-cdn.nexuspipe.com/fonts/Inter-5323287c005292e89e320f96952a52f6f45e7d570baff1ae5ad41c9d38a76dd13838025ef07489d53a847b5f201b1abaf7f1ba55c385d684ed7bc3082926c7f5.ttf') format('opentype');}`
+	)
+	.join('\n')}
+`;
+		else style?.remove();
 	});
 </script>
 
 <svelte:head>
 	<Fonts fonts={['Inter']} shouldPreload />
+	<style id="linux-font-moment"></style>
 </svelte:head>
 
 <slot />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,27 +1,59 @@
-<script>
+<script lang="ts">
 	import { invoke } from '@tauri-apps/api/tauri';
 	import { goto } from '$app/navigation';
 
 	import Button from '../lib/component/Button.svelte';
 	import Toggle from '../lib/component/Toggle.svelte';
-	import { userContext, UserContext, UserRank } from '../stores.ts';
+	import { userContext, UserContext, UserRank } from '../stores';
 	import {
 		addNotification,
 		Notification,
 		NotificationType,
 	} from '$lib/notif/NotifHandler';
 
-	let uid;
+	let uid: string = '';
+	let lastUid: string = '';
+	// force number
+	$: {
+		const _uid = uid.trim();
+		if (_uid === '' || _uid === '0x' || _uid === '0b') {
+			lastUid = uid;
+		} else if (isNaN(Number(_uid))) {
+			uid = lastUid;
+		} else {
+			lastUid = uid;
+		}
+	}
 	const unknownMessage =
 		'An unknown error occurred, please create an issue on GitHub';
+	export let remember_me = true;
+	/** Sets if we should save the user */
+	const save_remember_state = () => {
+		console.log(remember_me);
+
+		invoke('set_remember_state', {
+			state: remember_me,
+		});
+	};
 	const sign_in = async () => {
 		// TODO: backend implementation
+		uid = Number(uid.trim()).toString(); // convert to decimal
+		if (uid === 'NaN')
+			return addNotification(
+				new Notification(
+					'Invalid UID',
+					'Please enter a valid UID',
+					NotificationType.Err,
+					3e3
+				)
+			);
 		await invoke('login', {
 			uid: uid,
 		})
 			.then(async (response) => {
+				// get user data
 				let userData = new UserContext();
-				userData.serialize(response);
+				userData.serialize(response as object);
 				userContext.update((_) => userData);
 				localStorage.setItem(
 					'userContextData',
@@ -70,13 +102,6 @@
 				console.log(err);
 			});
 	};
-
-	const on_remember_update = (new_state) => {
-		// TODO: backend implementation
-		invoke('set_remember_state', {
-			state: new_state,
-		});
-	};
 </script>
 
 <main class="flex flex-col h-full justify-center items-center">
@@ -109,9 +134,9 @@
 				/>
 			</label>
 
-			<Toggle default_state="true" on:click={on_remember_update}>
-				Remember me
-			</Toggle>
+			<Toggle bind:checked={remember_me} on:click={save_remember_state}
+				>Remember me</Toggle
+			>
 
 			<Button on:click={sign_in}>Sign in</Button>
 		</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -109,13 +109,11 @@
 				/>
 			</label>
 
-			<Toggle
-				text="Remember me"
-				default_state="true"
-				on:click={on_remember_update}
-			/>
+			<Toggle default_state="true" on:click={on_remember_update}>
+				Remember me
+			</Toggle>
 
-			<Button text="Sign in" on:click={sign_in} />
+			<Button on:click={sign_in}>Sign in</Button>
 		</div>
 	</div>
 </main>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,11 +5,16 @@
 	import Button from '../lib/component/Button.svelte';
 	import Toggle from '../lib/component/Toggle.svelte';
 	import { userContext, UserContext, UserRank } from '../stores.ts';
-	import { addNotification, Notification } from '$lib/notif/NotifHandler';
+	import {
+		addNotification,
+		Notification,
+		NotificationType,
+	} from '$lib/notif/NotifHandler';
 
 	let uid;
-
-	async function sign_in() {
+	const unknownMessage =
+		'An unknown error occurred, please create an issue on GitHub';
+	const sign_in = async () => {
 		// TODO: backend implementation
 		await invoke('login', {
 			uid: uid,
@@ -23,6 +28,14 @@
 					JSON.stringify(response)
 				);
 				goto('/launcher');
+				addNotification(
+					new Notification(
+						'Logged in!',
+						'Logged in successfully',
+						NotificationType.Ok,
+						3e3
+					)
+				);
 			})
 			.catch((err) => {
 				let errorMessage = null;
@@ -31,22 +44,24 @@
 					errorMessage = err[error].message;
 				}
 				// If there is no message an unknown error occurred
-				if (errorMessage == null) {
-					errorMessage =
-						'An unknown error occurred, please create an issue on GitHub';
+				if (errorMessage === null || errorMessage === undefined) {
+					errorMessage = unknownMessage;
 				}
 				addNotification(
 					new Notification(
 						'Login Error',
 						errorMessage,
-						`error`,
+						NotificationType.Err,
 						100000,
 						true,
 						[
 							{
 								name: 'Copy',
 								callback: 'copy-text',
-								metadata: errorMessage,
+								metadata:
+									errorMessage === unknownMessage
+										? `${err}`
+										: errorMessage,
 							},
 						]
 					)
@@ -54,14 +69,14 @@
 				console.log(errorMessage);
 				console.log(err);
 			});
-	}
+	};
 
-	function on_remember_update(new_state) {
+	const on_remember_update = (new_state) => {
 		// TODO: backend implementation
 		invoke('set_remember_state', {
 			state: new_state,
 		});
-	}
+	};
 </script>
 
 <main class="flex flex-col h-full justify-center items-center">

--- a/src/routes/launcher/+page.svelte
+++ b/src/routes/launcher/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	import { Notification, addNotification } from '$lib/notif/NotifHandler';
+	import {
+		Notification,
+		NotificationType,
+		addNotification,
+	} from '$lib/notif/NotifHandler';
 	import Button from '../../lib/component/Button.svelte';
 
 	import SideBar from '../../lib/general/SideBar.svelte';
@@ -34,7 +38,7 @@
 								new Notification(
 									'Not implemented',
 									'This feature is not implemented yet.',
-									'warning',
+									NotificationType.Warn,
 									10e3,
 									true,
 									[]

--- a/src/routes/launcher/+page.svelte
+++ b/src/routes/launcher/+page.svelte
@@ -32,7 +32,6 @@
 					<Button
 						class="w-24"
 						full="false"
-						text="Install"
 						on:click={() => {
 							addNotification(
 								new Notification(
@@ -44,8 +43,8 @@
 									[]
 								)
 							);
-						}}
-					/>
+						}}>Install</Button
+					>
 				</div>
 			</div>
 		{/each}


### PR DESCRIPTION
## a tl;dr

This PR changes notifications to use per-type icons.
This PR changes notifications to use an enum for types.
This PR fixes some webkitgtk font-related stuff.
This PR improves general code practices for some components.

## details

This PR changes some notification behaviour, such as icons, an enum for types, etc...

It also hotfixes webkitgtk's inability to load variable fonts (:skull:) by setting every font weight from 100 to 900 manually. Due to caching & webkitgtk being not completely fucking retarded (unlike pre-chromium edge; shit still gives me nightmares), this can all be done while keeping only 1 woff2 request.

In addition, it replaces `text="<...>"` for Controls with [`<slot />`](https://svelte.dev/tutorial/slots)s (with [Slot Fallbacks](https://svelte.dev/tutorial/slot-fallbacks)), to remain similar to vanilla controls (see `<button>text</button>`), and overall is a good practice. This does not affect the look & feel of the launcher in any way.

Finally, we're using [`bind:checked`](https://svelte.dev/tutorial/component-bindings) over relying on the callback containing the value (it still does) for the checkbox.

## relevant svelte docs (for best practices related commits)
- [slots](https://svelte.dev/tutorial/slots)
- [slot fallbacks](https://svelte.dev/tutorial/slot-fallbacks)
- [component bindings](https://svelte.dev/tutorial/component-bindings)