### PR TITLE
fix!: code style, downloader, error messages

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -560,19 +560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
-name = "downloader"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05213e96f184578b5f70105d4d0a644a168e99e12d7bea0b200c15d67b5c182"
-dependencies = [
- "futures",
- "rand 0.8.5",
- "reqwest",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,28 +720,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -809,13 +780,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1669,7 +1636,6 @@ name = "moon-launcher"
 version = "1.0.0"
 dependencies = [
  "directories",
- "downloader",
  "lazy_static",
  "libloading",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lazy_static = "1.4.0"
 directories = "5.0.1"
-downloader = "0.2.7"
 libloading = "0.8.0"
 reqwest = "0.11.18"
 tokio = "1.28.1"

--- a/src-tauri/src/api/endpoint.rs
+++ b/src-tauri/src/api/endpoint.rs
@@ -3,12 +3,12 @@ use reqwest::header::HeaderMap;
 /// All different endpoint types available
 ///
 /// ### Explanation
-/// - NORMAL: A default http request with no extra properties such as additional headers
-/// - SERIAL: A http request with the user serial attached as a header
+/// - Normal: A default http request with no extra properties such as additional headers
+/// - Serial: A http request with the user serial attached as a header
 #[derive(PartialEq)]
 pub enum EndpointType {
-    NORMAL,
-    SERIAL,
+    Normal,
+    Serial,
 }
 
 /// The base endpoint trait

--- a/src-tauri/src/api/moon/download.rs
+++ b/src-tauri/src/api/moon/download.rs
@@ -40,6 +40,7 @@ pub struct DownloadRequestEndpointData {
 }
 
 /// Contains the response data as described in the [DownloadRequestEndpointData] documentation
+#[allow(dead_code)]
 #[derive(Deserialize)]
 pub struct DownloadResponseData {
     download_link: String,
@@ -47,25 +48,26 @@ pub struct DownloadResponseData {
 
 impl Endpoint for DownloadRequestEndpointData {
     fn url(&self) -> String {
-        return format!(
+        format!(
             "{BASE_URL}download/request?session_token={}&channel_name={}&channel_version={}",
             self.session_token, self.channel_name, self.channel_version
-        );
+        )
     }
 
     /// We don't need any authentication headers
     fn request_type(&self) -> EndpointType {
-        return EndpointType::NORMAL;
+        EndpointType::Normal
     }
 
     /// We don't need any special headers for this as the session token is passed
     /// through the query
     fn headers(&self) -> Option<HeaderMap> {
-        return None;
+        None
     }
 }
 
 /// All different errors with their mappings which can occur upon download requesting
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum DownloadRequestError {
     RequestFailed,
@@ -79,6 +81,7 @@ pub enum DownloadRequestError {
 }
 
 /// Authenticates with the backend servers
+#[allow(dead_code)]
 pub async fn request_download(
     state: &LauncherState,
     channel_name: String,
@@ -89,14 +92,17 @@ pub async fn request_download(
         channel_name,
         channel_version,
     };
-    let response = crate::api::requester::create_request(&state, endpoint)
+
+    let response = crate::api::requester::create_request(state, endpoint)
         .await
         .map_err(|_| RequestFailed)?;
+
     let status = response.status();
     let content = response
         .text_with_charset("UTF-8")
         .await
         .map_err(|_| RequestFailed)?;
+
     // Handle error mappings if status code is not ok
     if status != StatusCode::OK {
         return Err(match content.as_str() {
@@ -119,6 +125,7 @@ pub async fn request_download(
             _ => UnknownError,
         });
     }
+
     match serde_json::from_slice::<DownloadResponseData>(content.as_bytes()) {
         Ok(parsed) => Ok(parsed),
         _ => Err(JsonParseError),

--- a/src-tauri/src/api/requester.rs
+++ b/src-tauri/src/api/requester.rs
@@ -1,5 +1,5 @@
 use crate::api::endpoint::Endpoint;
-use crate::api::endpoint::EndpointType::SERIAL;
+use crate::api::endpoint::EndpointType::Serial;
 use crate::gui::LauncherState;
 use lazy_static::lazy_static;
 use reqwest::header::HeaderMap;
@@ -23,15 +23,18 @@ pub async fn create_request(
     endpoint: impl Endpoint,
 ) -> Result<Response, reqwest::Error> {
     let hwid = state.serial.as_str();
+
     let mut request_headers = endpoint.headers().unwrap_or(HeaderMap::new());
     request_headers.insert("User-Agent", HeaderValue::from_static(USER_AGENT));
+
     // If the request wants a serial code header we have to put it now
-    if endpoint.request_type() == SERIAL {
+    if endpoint.request_type() == Serial {
         request_headers.insert(
             "Launcher-User-Serial",
             HeaderValue::from_str(hwid).unwrap_or(HeaderValue::from_static(FALLBACK_SERIAL)),
         );
     }
+
     REQWEST_CLIENT
         .get(endpoint.url())
         .headers(request_headers)

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -1,6 +1,5 @@
 use tauri::async_runtime::Mutex;
 
-use crate::api::moon::auth::{AuthenticationError, AuthenticationResponseData};
 use crate::storage::types::{GameSettingData, LoginSettingData, VersionSettingData};
 
 pub mod folder;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,7 +4,6 @@
 use tauri::async_runtime::Mutex;
 
 use crate::gui::LauncherState;
-use crate::proprietary::PROPRIETARY_LIBRARY;
 
 mod api;
 mod gui;

--- a/src-tauri/src/storage/location.rs
+++ b/src-tauri/src/storage/location.rs
@@ -1,6 +1,6 @@
 use directories::BaseDirs;
 use lazy_static::lazy_static;
-use std::env;
+
 use std::fs::create_dir_all;
 use std::path::PathBuf;
 
@@ -12,10 +12,10 @@ lazy_static! {
     /// The launcher won't be able to operate properly if we are unable to create this directory.
     /// It is simply **REQUIRED** to proceed
     pub static ref MOON_WORKING_DIRECTORY: PathBuf = {
-        resolve_working_directory().unwrap()
+        resolve_working_directory().expect("Working directory could not be created")
     };
     pub static ref MINECRAFT_WORKING_DIRECTORY: PathBuf = {
-        resolve_minecraft_directory().unwrap()
+        resolve_minecraft_directory().expect("Minecraft directory could not be created")
     };
 }
 
@@ -36,10 +36,13 @@ pub fn resolve_working_directory() -> Result<PathBuf, StorageLocationError> {
         Some(dir) => dir,
         _ => return Err(StorageLocationError::BaseDirectoriesMissing),
     };
+
     let mut working_dir = PathBuf::from(user_base_dirs.data_dir());
     working_dir.push(".moon/");
+
     create_dir_all(&working_dir)
         .map_err(|_| StorageLocationError::UnableToCreateWorkingDirectory)?;
+
     Ok(working_dir)
 }
 
@@ -53,9 +56,12 @@ pub fn resolve_minecraft_directory() -> Result<PathBuf, StorageLocationError> {
         Some(dir) => dir,
         _ => return Err(StorageLocationError::BaseDirectoriesMissing),
     };
+
     let mut minecraft_dir = PathBuf::from(user_base_dirs.data_dir());
     minecraft_dir.push(".minecraft/");
+
     create_dir_all(&minecraft_dir)
         .map_err(|_| StorageLocationError::UnableToCreateWorkingDirectory)?;
+
     Ok(minecraft_dir)
 }

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -14,9 +14,11 @@ pub trait NamedStorage {
 }
 
 /// All different storage types available (all storages listed are saved in JSON format)
+#[derive(Debug)]
 pub enum StorageType {
     Login,
     GameSettings,
+    #[allow(dead_code)]
     WineSettings, // TODO: Those are for later once Wine is actually implemented
     VersionSettings,
 }
@@ -24,21 +26,23 @@ pub enum StorageType {
 /// All errors which can occur upon saving or loading config files
 #[derive(Debug, Serialize, Deserialize)]
 pub enum StorageError {
-    FileOpenError { message: &'static str },
-    JsonSerializeError { message: &'static str },
-    StorageSaveError { message: &'static str },
-    StorageLoadError { message: &'static str },
+    FileOpen { message: &'static str },
+    JsonSerialize { message: &'static str },
+    StorageSave { message: &'static str },
+    StorageLoad { message: &'static str },
 }
 
 impl NamedStorage for StorageType {
     fn file_name(&self) -> &'static str {
-        return match self {
+        match self {
             StorageType::Login => "login",
             StorageType::GameSettings => "game",
             StorageType::WineSettings => "wine",
             StorageType::VersionSettings => "version",
-            _ => "unknown",
-        };
+
+            #[allow(unreachable_patterns)]
+            _ => unreachable!("Unknown storage type: {:?}", self),
+        }
     }
 }
 
@@ -47,21 +51,20 @@ pub fn save_storage_data<T: Serialize>(
     storage_type: StorageType,
     data: T,
 ) -> Result<(), StorageError> {
-    let serialized =
-        serde_json::to_string(&data).map_err(|_| StorageError::JsonSerializeError {
-            message: "Failed to serialize given storage data",
-        })?;
+    let serialized = serde_json::to_string(&data).map_err(|_| StorageError::JsonSerialize {
+        message: "Failed to serialize given storage data",
+    })?;
 
     let mut storage_path = MOON_WORKING_DIRECTORY.clone();
     storage_path.push(format!("{}.json", storage_type.file_name()));
     let mut storage_file =
-        File::create(storage_path.as_path()).map_err(|_| StorageError::FileOpenError {
+        File::create(storage_path.as_path()).map_err(|_| StorageError::FileOpen {
             message: "Failed to create or open the storage file path",
         })?;
 
     storage_file
         .write_all(serialized.as_bytes())
-        .map_err(|_| StorageError::StorageSaveError {
+        .map_err(|_| StorageError::StorageSave {
             message: "Failed to write storage file to path",
         })?;
     Ok(())
@@ -77,7 +80,8 @@ pub fn load_storage_data<T: serde::de::DeserializeOwned + Serialize>(
 ) -> Result<T, StorageError> {
     let mut storage_path = MOON_WORKING_DIRECTORY.clone();
     storage_path.push(format!("{}.json", storage_type.file_name()));
-    let mut storage_file = match File::open(storage_path.as_path()) {
+
+    let storage_file = match File::open(storage_path.as_path()) {
         Ok(file) => file,
         _ => {
             // Save default data if we are unable to open the file
@@ -85,17 +89,18 @@ pub fn load_storage_data<T: serde::de::DeserializeOwned + Serialize>(
                 Ok(_) => {}
                 Err(save_err) => return Err(save_err),
             };
+
             // This error **will** be ignored inside the GUI as it just means that no data has been saved yet
-            return Err(StorageError::FileOpenError {
+            return Err(StorageError::FileOpen {
                 message: "Failed to open file",
             });
         }
     };
 
-    return match serde_json::from_reader(storage_file) {
+    match serde_json::from_reader(storage_file) {
         Ok(t) => Ok(t),
-        _ => Err(StorageError::JsonSerializeError {
+        _ => Err(StorageError::JsonSerialize {
             message: "Failed to deserialize file content of storage type",
         }),
-    };
+    }
 }


### PR DESCRIPTION
This pull request includes various improvements to the current Rust codebase.

Proprietary library downloader:
- Removed dependency on the [downloader crate](https://lib.rs/crates/downloader), as we already depend on [reqwest](https://lib.rs/crates/reqwest). Replaced the calls with reqwest, this also fixes library download errors I was encountering, such as: `/home/vape/.local/share/.moon/liblauncher_lib-1.0.so: file too short` (this was probably caused by the download failing and writing an empty file / missing some bytes)
- This will need to be improved in the future, however currently Tauri has a limitation with tokio, so you need to wrap `block_on` calls in `tauri::task::block_in_place`. We need this since reqwest is an async library and `lazy_static!` does not support async initializers. We also can't use the `blocking` feature for reqwest as it conflicts with Tauri's tokio.

Code Style changes:
- Removed unused imports
- Renamed enum variants to match Rust conventions
- Fixed all clippy warnings, and silenced the irrelevant ones in places that will change in the future
- Reformatted code to match Rust conventions, and to increase readability by adding empty lines to separate lines
- Replaced all `unwrap` calls with `expect` so we can provide a clearer error message

Proposed further improvements:
- Perhaps we could replace `lazy_static!` with the newly stabilized `OnceCell` ([Announcing Rust 1.70.0 - OnceCell and OnceLock](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#oncecell-and-oncelock))?